### PR TITLE
Implement pre-signed url method in the Bucket object

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ end
 
 ## Usage
 
+### Upload a file
+
 ```
 file_to_upload = Tempfile.new("test-upload-file.csv")
 bucket = DefraRuby::Aws.get_bucket("defra-ruby-aws")
@@ -56,6 +58,13 @@ else
   response.error # return the failure error
   # Do something else
 end
+```
+
+### Generate a presigned URL for download
+
+```
+bucket = DefraRuby::Aws.get_bucket("defra-ruby-aws")
+presigned_url = bucket.presigned_url("test-upload-file.csv")
 ```
 
 ## Contributing to this project

--- a/lib/defra_ruby/aws.rb
+++ b/lib/defra_ruby/aws.rb
@@ -4,7 +4,9 @@ require_relative "aws/bucket"
 require_relative "aws/response"
 require_relative "aws/configuration"
 
+require_relative "aws/services/concerns/has_aws_bucket_configuration"
 require_relative "aws/services/bucket_loader_service"
+require_relative "aws/services/presigned_url_service"
 
 module DefraRuby
   module Aws

--- a/lib/defra_ruby/aws/bucket.rb
+++ b/lib/defra_ruby/aws/bucket.rb
@@ -25,6 +25,10 @@ module DefraRuby
         BucketLoaderService.run(self, file)
       end
 
+      def presigned_url(file_name)
+        PresignedUrlService.run(self, file_name)
+      end
+
       private
 
       attr_writer :region

--- a/lib/defra_ruby/aws/services/bucket_loader_service.rb
+++ b/lib/defra_ruby/aws/services/bucket_loader_service.rb
@@ -3,6 +3,8 @@
 module DefraRuby
   module Aws
     class BucketLoaderService
+      include HasAwsBucketConfiguration
+
       def self.run(bucket, file)
         new(bucket, file).run
       end
@@ -19,21 +21,6 @@ module DefraRuby
       private
 
       attr_reader :bucket, :file
-
-      def s3_bucket
-        s3.bucket(bucket.bucket_name)
-      end
-
-      def s3
-        ::Aws::S3::Resource.new(
-          region: bucket.region,
-          credentials: aws_credentials
-        )
-      end
-
-      def aws_credentials
-        ::Aws::Credentials.new(bucket.access_key_id, bucket.secret_access_key)
-      end
 
       def response_exe
         lambda do

--- a/lib/defra_ruby/aws/services/concerns/has_aws_bucket_configuration.rb
+++ b/lib/defra_ruby/aws/services/concerns/has_aws_bucket_configuration.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module DefraRuby
+  module Aws
+    module HasAwsBucketConfiguration
+      def s3_bucket
+        s3.bucket(bucket.bucket_name)
+      end
+
+      def s3
+        ::Aws::S3::Resource.new(
+          region: bucket.region,
+          credentials: aws_credentials
+        )
+      end
+
+      def aws_credentials
+        ::Aws::Credentials.new(bucket.access_key_id, bucket.secret_access_key)
+      end
+    end
+  end
+end

--- a/lib/defra_ruby/aws/services/presigned_url_service.rb
+++ b/lib/defra_ruby/aws/services/presigned_url_service.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module DefraRuby
+  module Aws
+    class PresignedUrlService
+      include HasAwsBucketConfiguration
+
+      def self.run(bucket, file_name)
+        new(bucket, file_name).run
+      end
+
+      def initialize(bucket, file_name)
+        @bucket = bucket
+        @file_name = file_name
+      end
+
+      def run
+        s3_bucket.object(file_name).presigned_url(
+          :get,
+          expires_in: 20 * 60, # 20 minutes in seconds
+          secure: true,
+          response_content_type: "text/csv",
+          response_content_disposition: "attachment; filename=#{file_name}"
+        )
+      end
+
+      private
+
+      attr_reader :bucket, :file_name
+    end
+  end
+end

--- a/spec/lib/defra_ruby/aws/services/presigned_url_service_spec.rb
+++ b/spec/lib/defra_ruby/aws/services/presigned_url_service_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module DefraRuby
+  module Aws
+    RSpec.describe PresignedUrlService do
+      describe ".run" do
+        let(:configs) do
+          {
+            name: "test",
+            credentials: {
+              access_key_id: "123",
+              secret_access_key: "Secret"
+            }
+          }
+        end
+        let(:bucket) { Bucket.new(configs) }
+        let(:presigned_url) { described_class.run(bucket, "testfile.csv") }
+
+        it "returns a presigned url for a given file in the bucket" do
+          expect(presigned_url).to include("https://test.s3.eu-west-1.amazonaws.com/testfile.csv")
+          expect(presigned_url).to include("response-content-disposition=attachment")
+          expect(presigned_url).to include("response-content-type=text%2Fcsv")
+          expect(presigned_url).to include("Amz-Expires")
+          expect(presigned_url).to include("Amz-Credential")
+          expect(presigned_url).to include("Amz-Signature")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
A handy method to generate a pre-signed URL to download CSV files from the bucket.