### PR TITLE
Update .travis.yml to send test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,19 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=9a0d95efc12238c195685a08da6071e41d25bf6475723adf8f419095b56e0ac5
+
 language: ruby
 rvm: 2.4.2
 cache: bundler
 
 # Travis CI clones repositories to a depth of 50 commits, which is only really
 # useful if you are performing git operations.
-# https://docs.travis-ci.com/user/customizing-the-build/#git-clone-depth
+# https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth
 git:
   depth: 3
+
+before_install:
+  - export TZ=UTC
 
 before_script:
   # Setup to support the CodeClimate test coverage submission

--- a/spec/support/simplecov.rb
+++ b/spec/support/simplecov.rb
@@ -7,11 +7,7 @@ require "simplecov"
 # This gives us the most accurate assessment of our unit test coverage
 # https://github.com/colszowka/simplecov#getting-started
 SimpleCov.start do
-  # We filter the spec folder, mainly to ensure that any dummy apps don't get
-  # included in the coverage report. However our intent is that nothing in the
-  # spec folder should be included
-  add_filter "/spec/"
   # The version file is simply just that, so we do not feel the need to ensure
   # we have a test for it
-  add_filter "lib/defra_ruby/validators/version"
+  add_filter "lib/defra_ruby/aws/version"
 end


### PR DESCRIPTION
This changes updates the format of the travis.yml to match our general format, as well as ensuring it is configured to send test coverage stats to codeclimate.