### PR TITLE
Update gemspec to match our other gems

### DIFF
--- a/defra_ruby_aws.gemspec
+++ b/defra_ruby_aws.gemspec
@@ -1,27 +1,29 @@
 # frozen_string_literal: true
 
-lib = File.expand_path("lib", __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+$LOAD_PATH.push File.expand_path("lib", __dir__)
 
 require_relative "./lib/defra_ruby"
 require_relative "./lib/defra_ruby/aws/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "defra-ruby-aws"
+  spec.name          = "defra_ruby_aws"
   spec.version       = DefraRuby::Aws::VERSION
   spec.authors       = ["Defra"]
-  spec.email         = ["cintamani.puddu@gmail.com"]
-
-  spec.summary       = "DEFRA Aws helpers"
-  spec.description   = "DEFRA AWS helpers for connecting Rails application to the DEFRA AWS instances."
-  spec.homepage      = "https://github.com/DEFRA/defra-ruby-aws"
+  spec.email         = ["alan.cruikshanks@environment-agency.gov.uk"]
   spec.license       = "The Open Government Licence (OGL) Version 3"
+  spec.homepage      = "https://github.com/DEFRA/defra-ruby-aws"
+  spec.summary       = "Defra ruby on rails AWS helpers"
+  spec.description   = "Package of AWS features commonly used in Defra Rails based digital services"
+
+  spec.files = Dir["{bin,config,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
+  spec.test_files = Dir["spec/**/*"]
+
+  spec.require_paths = ["lib"]
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata["homepage_uri"] = spec.homepage
-    spec.metadata["source_code_uri"] = spec.homepage
+    spec.metadata["allowed_push_host"] = "https://rubygems.org"
   else
     raise "RubyGems 2.0 or newer is required to protect against " \
       "public gem pushes."
@@ -29,14 +31,6 @@ Gem::Specification.new do |spec|
 
   # Use the AWS SDK to interact with S3
   spec.add_dependency "aws-sdk-s3"
-
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
-  spec.test_files = Dir["spec/**/*"]
-  spec.require_paths = ["lib"]
 
   spec.add_development_dependency "defra_ruby_style"
   # Shim to load environment variables from a .env file into ENV
@@ -51,7 +45,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "webmock"
 end


### PR DESCRIPTION
This updates the gemspec file content and format to match that used in [Defra Ruby Style](https://github.com/DEFRA/defra-ruby-style) and [Defra Ruby Validators](https://github.com/DEFRA/defra-ruby-validators). Specific changes are

- update to the `$LOAD_PATH` statement at top of file. Don't actually know which is better, this change is just about consistency
- `spec.name` in our other gems is snake case rather than kebab case so updated to match
- `spec.summary` and `spec.description` have been expanded
- `spec.email` is set to @cruikshanks. In lieu of a central mailbox anything Ruby based released to rubygems uses the @environment-agency.gov.uk address in case we receive any requests for info. We certainly can't use private email addresses
- `spec.files` has switched from 'add files except' to be 'add only these files'
- updated the `spec.respond_to?` to be consistent. Again don't know which is best, this change is just about consistency
- dropped the explicit dev dependency for `rubocop`. It comes in via `defra_ruby_style` (though we seem to also declare it in `defra_ruby_validators` so that will be fixed asap as well!)