### PR TITLE
Fix code coverage

### DIFF
--- a/defra_ruby_aws.gemspec
+++ b/defra_ruby_aws.gemspec
@@ -2,8 +2,8 @@
 
 $LOAD_PATH.push File.expand_path("lib", __dir__)
 
-require_relative "./lib/defra_ruby"
-require_relative "./lib/defra_ruby/aws/version"
+# Maintain your gem"s version:
+require "defra_ruby/aws/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "defra_ruby_aws"

--- a/spec/support/defra_ruby_aws.rb
+++ b/spec/support/defra_ruby_aws.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Need to require our actual code files.
+require "defra_ruby/aws"

--- a/spec/support/simplecov.rb
+++ b/spec/support/simplecov.rb
@@ -7,6 +7,10 @@ require "simplecov"
 # This gives us the most accurate assessment of our unit test coverage
 # https://github.com/colszowka/simplecov#getting-started
 SimpleCov.start do
+  # We filter the spec folder, mainly to ensure that any dummy apps don't get
+  # included in the coverage report. However our intent is that nothing in the
+  # spec folder should be included
+  add_filter "/spec/"
   # The version file is simply just that, so we do not feel the need to ensure
   # we have a test for it
   add_filter "lib/defra_ruby/aws/version"


### PR DESCRIPTION
PR #16 switched this project from CodeClimate to SonarCloud. When on CodeClimate our code coverage was 100% 🥳 After switching to SonarCloud its 0% 😱

After running it locally and checking what SimpleCov is reporting, it starts to make sense. SonarCloud we have learnt does not just take the final figure SimpleCov spits out. Instead, it compares the details in `coverage/.resultset.json` with the code files to confirm what has been covered.

If you look at the detail of the SimpleCov report, it's listing only the files in `spec/`! It shows there is no coverage for the actual code in `lib/`, but still reports 100%. Hence when SonarCloud analyses the results it comes back with a big fat 0.

This PR is about fixing the test coverage so we can report accurately what test coverage we have.

<details>
<summary>SimpleCov before</summary>

![Screenshot 2020-03-12 at 10 13 01](https://user-images.githubusercontent.com/1789650/76512126-16bd0580-644c-11ea-92de-8d30e763e06f.png)

</details>

<details>
<summary>SimpleCov after</summary>

![Screenshot 2020-03-12 at 10 22 30](https://user-images.githubusercontent.com/1789650/76512151-24728b00-644c-11ea-9355-5e79bc57f035.png)

</details>