### PR TITLE
Fix issue in travis with bundler args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ git:
 
 before_install:
   - export TZ=UTC
-  - gem install -v 1.17.3 bundler --no-rdoc --no-ri
+  - gem install -v 1.17.3 bundler --no-document
 
 script:
   - bundle exec rubocop --format progress --format json --out rubocop-result.json

--- a/spec/features/upload_file_to_bucket_spec.rb
+++ b/spec/features/upload_file_to_bucket_spec.rb
@@ -37,13 +37,13 @@ RSpec.describe "Defra Ruby AWS" do
   end
 
   def stub_successful_request
-    stub_request(:put, %r{https:\/\/bulk-test\.s3\.eu-west-1\.amazonaws\.com\/test-bucket-load\..+})
+    stub_request(:put, %r{https://bulk-test\.s3\.eu-west-1\.amazonaws\.com/test-bucket-load\..+})
   end
 
   def stub_failing_request
     stub_request(
       :put,
-      %r{https:\/\/bulk-test\.s3\.eu-west-1\.amazonaws\.com\/test-bucket-load\..+}
+      %r{https://bulk-test\.s3\.eu-west-1\.amazonaws\.com/test-bucket-load\..+}
     ).to_return(
       status: 403
     )


### PR DESCRIPTION
Problem:

Back in May we started seeing a number of projects Travis builds failing.

The error is:

```
$ gem install -v 1.17.3 bundler --no-rdoc --no-ri
ERROR:  While executing gem ... (OptionParser::InvalidOption)
    invalid option: --no-rdoc
The command "gem install -v 1.17.3 bundler --no-rdoc --no-ri" failed and exited with 1 during .
```

Visible in https://travis-ci.com/github/DEFRA/defra-ruby-aws/builds/170472128

We think the only difference in the builds is the version of the ruby binary Travis is pulling. But for now we are simply going to switch our args to move past the issue and get things building again.