### PR TITLE
Switch upload to use aws:kms encryption

### DIFF
--- a/lib/defra_ruby/aws/services/bucket_loader_service.rb
+++ b/lib/defra_ruby/aws/services/bucket_loader_service.rb
@@ -24,7 +24,7 @@ module DefraRuby
 
       def response_exe
         lambda do
-          s3_bucket.object(File.basename(file.path)).upload_file(file.path, server_side_encryption: :AES256)
+          s3_bucket.object(File.basename(file.path)).upload_file(file.path, server_side_encryption: "aws:kms")
         end
       end
     end

--- a/spec/lib/defra_ruby/aws/services/bucket_loader_service_spec.rb
+++ b/spec/lib/defra_ruby/aws/services/bucket_loader_service_spec.rb
@@ -27,7 +27,7 @@ module DefraRuby
           expect(::Aws::S3::Resource).to receive(:new).and_return(aws_resource)
           expect(aws_resource).to receive(:bucket).with("bulk").and_return(s3_bucket)
           expect(s3_bucket).to receive(:object).with("test.csv").and_return(s3_object)
-          expect(s3_object).to receive(:upload_file).with("foo/bar/baz/test.csv", server_side_encryption: :AES256).and_return(result)
+          expect(s3_object).to receive(:upload_file).with("foo/bar/baz/test.csv", server_side_encryption: "aws:kms").and_return(result)
 
           expect(described_class.run(bucket, file)).to be_a(Response)
         end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1099

The gem has alwasy encrypted on upload. This means irrespective of whether encryption at rest is enabled on the bucket, any file we upload is encrypted.

After a recent review and consultation with AWS, our web-ops team is intending to go through all AWS S3 buckets and set the policy that [all uploads are required to be encrypted using KMS](https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/s3-example-enforce-server-side-encryption.html).

We have tested with a bucket where this has been applied and the current upload still works fine. But to ensure there are no issues going forward this change switches the type of encryption we use on upload to KMS.

This change should not effect any services still using buckets without the policy. The key thing is whatever we upload is still encrypted. This will just mean when those services are updated they should not encounter any issues with their S3 uploads.