### PR TITLE
Add options to upload file in subfolder

### DIFF
--- a/lib/defra_ruby/aws/bucket.rb
+++ b/lib/defra_ruby/aws/bucket.rb
@@ -26,16 +26,16 @@ module DefraRuby
         @_encryption_type ||= @encrypt_with_kms ? "aws:kms" : :AES256
       end
 
-      def load(file)
-        BucketLoaderService.run(self, file)
+      def load(file, options = {})
+        BucketLoaderService.run(self, file, options)
       end
 
-      def presigned_url(file_name)
-        PresignedUrlService.run(self, file_name)
+      def presigned_url(file_name, options = {})
+        PresignedUrlService.run(self, file_name, options)
       end
 
-      def delete(file_name)
-        DeleteFileFromBucketService.run(self, file_name)
+      def delete(file_name, options = {})
+        DeleteFileFromBucketService.run(self, file_name, options)
       end
 
       private

--- a/lib/defra_ruby/aws/services/bucket_loader_service.rb
+++ b/lib/defra_ruby/aws/services/bucket_loader_service.rb
@@ -12,7 +12,7 @@ module DefraRuby
       def initialize(bucket, file, options)
         @bucket = bucket
         @file = file
-        @dir = options[:upload_directory]
+        @dir = options[:s3_directory]
       end
 
       def run
@@ -21,7 +21,7 @@ module DefraRuby
 
       private
 
-      attr_reader :bucket, :file
+      attr_reader :bucket, :file, :dir
 
       def response_exe
         lambda do
@@ -32,7 +32,7 @@ module DefraRuby
       end
 
       def destination
-        [*@dir, File.basename(file.path)].compact.join("/")
+        [*dir, File.basename(file.path)].compact.join("/")
       end
     end
   end

--- a/lib/defra_ruby/aws/services/bucket_loader_service.rb
+++ b/lib/defra_ruby/aws/services/bucket_loader_service.rb
@@ -5,13 +5,14 @@ module DefraRuby
     class BucketLoaderService
       include HasAwsBucketConfiguration
 
-      def self.run(bucket, file)
-        new(bucket, file).run
+      def self.run(bucket, file, options = {})
+        new(bucket, file, options).run
       end
 
-      def initialize(bucket, file)
+      def initialize(bucket, file, options)
         @bucket = bucket
         @file = file
+        @dir = options[:upload_directory]
       end
 
       def run
@@ -25,9 +26,13 @@ module DefraRuby
       def response_exe
         lambda do
           s3_bucket
-            .object(File.basename(file.path))
+            .object(destination)
             .upload_file(file.path, server_side_encryption: bucket.encryption_type)
         end
+      end
+
+      def destination
+        [*@dir, File.basename(file.path)].compact.join("/")
       end
     end
   end

--- a/lib/defra_ruby/aws/services/delete_file_from_bucket_service.rb
+++ b/lib/defra_ruby/aws/services/delete_file_from_bucket_service.rb
@@ -5,13 +5,14 @@ module DefraRuby
     class DeleteFileFromBucketService
       include HasAwsBucketConfiguration
 
-      def self.run(bucket, file_name)
-        new(bucket, file_name).run
+      def self.run(bucket, file_name, options = {})
+        new(bucket, file_name, options).run
       end
 
-      def initialize(bucket, file_name)
+      def initialize(bucket, file_name, options)
         @bucket = bucket
         @file_name = file_name
+        @dir = options[:s3_directory]
       end
 
       def run
@@ -20,14 +21,18 @@ module DefraRuby
 
       private
 
-      attr_reader :bucket, :file_name
+      attr_reader :bucket, :file_name, :dir
 
       def response_exe
         lambda do
-          delete_object_output = s3_bucket.object(file_name).delete
+          delete_object_output = s3_bucket.object(destination).delete
 
           delete_object_output.request_charged.length.positive?
         end
+      end
+
+      def destination
+        [*dir, file_name].compact.join("/")
       end
     end
   end

--- a/lib/defra_ruby/aws/services/presigned_url_service.rb
+++ b/lib/defra_ruby/aws/services/presigned_url_service.rb
@@ -5,17 +5,18 @@ module DefraRuby
     class PresignedUrlService
       include HasAwsBucketConfiguration
 
-      def self.run(bucket, file_name)
-        new(bucket, file_name).run
+      def self.run(bucket, file_name, options = {})
+        new(bucket, file_name, options).run
       end
 
-      def initialize(bucket, file_name)
+      def initialize(bucket, file_name, options)
         @bucket = bucket
         @file_name = file_name
+        @dir = options[:s3_directory]
       end
 
       def run
-        s3_bucket.object(file_name).presigned_url(
+        s3_bucket.object(destination).presigned_url(
           :get,
           expires_in: 20 * 60, # 20 minutes in seconds
           secure: true,
@@ -26,7 +27,11 @@ module DefraRuby
 
       private
 
-      attr_reader :bucket, :file_name
+      attr_reader :bucket, :file_name, :dir
+
+      def destination
+        [*dir, file_name].compact.join("/")
+      end
     end
   end
 end

--- a/spec/lib/defra_ruby/aws/bucket_spec.rb
+++ b/spec/lib/defra_ruby/aws/bucket_spec.rb
@@ -230,9 +230,10 @@ module DefraRuby
         it "loads the given file to the s3 bucket" do
           result = double(:result)
           file = double(:file)
+          options = double(:options)
 
-          expect(BucketLoaderService).to receive(:run).with(bucket, file).and_return(result)
-          expect(bucket.load(file)).to eq(result)
+          expect(BucketLoaderService).to receive(:run).with(bucket, file, options).and_return(result)
+          expect(bucket.load(file, options)).to eq(result)
         end
       end
     end

--- a/spec/lib/defra_ruby/aws/services/bucket_loader_service_spec.rb
+++ b/spec/lib/defra_ruby/aws/services/bucket_loader_service_spec.rb
@@ -32,6 +32,24 @@ module DefraRuby
 
             expect(described_class.run(bucket, file)).to be_a(Response)
           end
+
+          context "when an upload_directory is provided" do
+            it "loads the given file to the s3 bucket at the correct location using AWS:KMS" do
+              aws_resource = double(:aws_resource)
+              s3_bucket = double(:s3_bulk_bucket)
+              file = double(:file, path: "foo/bar/baz/test.csv")
+              s3_object = double(:s3_object)
+              result = double(:result)
+              options = { upload_directory: "directory" }
+
+              expect(::Aws::S3::Resource).to receive(:new).and_return(aws_resource)
+              expect(aws_resource).to receive(:bucket).with("bulk").and_return(s3_bucket)
+              expect(s3_bucket).to receive(:object).with("directory/test.csv").and_return(s3_object)
+              expect(s3_object).to receive(:upload_file).with("foo/bar/baz/test.csv", server_side_encryption: :AES256).and_return(result)
+
+              expect(described_class.run(bucket, file, options)).to be_a(Response)
+            end
+          end
         end
 
         context "when 'encrypt_with_kms' is set" do
@@ -56,6 +74,24 @@ module DefraRuby
             expect(s3_object).to receive(:upload_file).with("foo/bar/baz/test.csv", server_side_encryption: "aws:kms").and_return(result)
 
             expect(described_class.run(bucket, file)).to be_a(Response)
+          end
+
+          context "when an upload_directory is provided" do
+            it "loads the given file to the s3 bucket at the correct location using AWS:KMS" do
+              aws_resource = double(:aws_resource)
+              s3_bucket = double(:s3_bulk_bucket)
+              file = double(:file, path: "foo/bar/baz/test.csv")
+              s3_object = double(:s3_object)
+              result = double(:result)
+              options = { upload_directory: ["directory", "second_directory"] }
+
+              expect(::Aws::S3::Resource).to receive(:new).and_return(aws_resource)
+              expect(aws_resource).to receive(:bucket).with("bulk").and_return(s3_bucket)
+              expect(s3_bucket).to receive(:object).with("directory/second_directory/test.csv").and_return(s3_object)
+              expect(s3_object).to receive(:upload_file).with("foo/bar/baz/test.csv", server_side_encryption: "aws:kms").and_return(result)
+
+              expect(described_class.run(bucket, file, options)).to be_a(Response)
+            end
           end
         end
       end

--- a/spec/lib/defra_ruby/aws/services/bucket_loader_service_spec.rb
+++ b/spec/lib/defra_ruby/aws/services/bucket_loader_service_spec.rb
@@ -83,7 +83,7 @@ module DefraRuby
               file = double(:file, path: "foo/bar/baz/test.csv")
               s3_object = double(:s3_object)
               result = double(:result)
-              options = { s3_directory: ["directory", "second_directory"] }
+              options = { s3_directory: %w[directory second_directory] }
 
               expect(::Aws::S3::Resource).to receive(:new).and_return(aws_resource)
               expect(aws_resource).to receive(:bucket).with("bulk").and_return(s3_bucket)

--- a/spec/lib/defra_ruby/aws/services/bucket_loader_service_spec.rb
+++ b/spec/lib/defra_ruby/aws/services/bucket_loader_service_spec.rb
@@ -33,14 +33,14 @@ module DefraRuby
             expect(described_class.run(bucket, file)).to be_a(Response)
           end
 
-          context "when an upload_directory is provided" do
+          context "when an s3_directory is provided" do
             it "loads the given file to the s3 bucket at the correct location using AWS:KMS" do
               aws_resource = double(:aws_resource)
               s3_bucket = double(:s3_bulk_bucket)
               file = double(:file, path: "foo/bar/baz/test.csv")
               s3_object = double(:s3_object)
               result = double(:result)
-              options = { upload_directory: "directory" }
+              options = { s3_directory: "directory" }
 
               expect(::Aws::S3::Resource).to receive(:new).and_return(aws_resource)
               expect(aws_resource).to receive(:bucket).with("bulk").and_return(s3_bucket)
@@ -76,14 +76,14 @@ module DefraRuby
             expect(described_class.run(bucket, file)).to be_a(Response)
           end
 
-          context "when an upload_directory is provided" do
+          context "when an s3_directory is provided" do
             it "loads the given file to the s3 bucket at the correct location using AWS:KMS" do
               aws_resource = double(:aws_resource)
               s3_bucket = double(:s3_bulk_bucket)
               file = double(:file, path: "foo/bar/baz/test.csv")
               s3_object = double(:s3_object)
               result = double(:result)
-              options = { upload_directory: ["directory", "second_directory"] }
+              options = { s3_directory: ["directory", "second_directory"] }
 
               expect(::Aws::S3::Resource).to receive(:new).and_return(aws_resource)
               expect(aws_resource).to receive(:bucket).with("bulk").and_return(s3_bucket)

--- a/spec/lib/defra_ruby/aws/services/delete_file_from_bucket_service_spec.rb
+++ b/spec/lib/defra_ruby/aws/services/delete_file_from_bucket_service_spec.rb
@@ -76,7 +76,7 @@ module DefraRuby
               file_name = "test.csv"
               s3_object = double(:s3_object)
               result = double(:result, request_charged: "")
-              options = { s3_directory: ["directory", "second_directory"] }
+              options = { s3_directory: %w[directory second_directory] }
 
               expect(::Aws::S3::Resource).to receive(:new).and_return(aws_resource)
               expect(aws_resource).to receive(:bucket).with("bulk").and_return(s3_bucket)

--- a/spec/lib/defra_ruby/aws/services/delete_file_from_bucket_service_spec.rb
+++ b/spec/lib/defra_ruby/aws/services/delete_file_from_bucket_service_spec.rb
@@ -33,6 +33,25 @@ module DefraRuby
           expect(response).to be_successful
         end
 
+        context "when an s3_directory is provided" do
+          it "returns a successful response" do
+            aws_resource = double(:aws_resource)
+            s3_bucket = double(:s3_bulk_bucket)
+            file_name = "test.csv"
+            s3_object = double(:s3_object)
+            result = double(:result, request_charged: "present")
+            options = { s3_directory: "directory" }
+
+            expect(::Aws::S3::Resource).to receive(:new).and_return(aws_resource)
+            expect(aws_resource).to receive(:bucket).with("bulk").and_return(s3_bucket)
+            expect(s3_bucket).to receive(:object).with("directory/test.csv").and_return(s3_object)
+            expect(s3_object).to receive(:delete).and_return(result)
+
+            response = described_class.run(bucket, file_name, options)
+            expect(response).to be_successful
+          end
+        end
+
         context "when the response body returns an empty charged requests" do
           it "returns a non successful response" do
             aws_resource = double(:aws_resource)
@@ -48,6 +67,25 @@ module DefraRuby
 
             response = described_class.run(bucket, file_name)
             expect(response).to_not be_successful
+          end
+
+          context "when an s3_directory is provided" do
+            it "returns a non successful response" do
+              aws_resource = double(:aws_resource)
+              s3_bucket = double(:s3_bulk_bucket)
+              file_name = "test.csv"
+              s3_object = double(:s3_object)
+              result = double(:result, request_charged: "")
+              options = { s3_directory: ["directory", "second_directory"] }
+
+              expect(::Aws::S3::Resource).to receive(:new).and_return(aws_resource)
+              expect(aws_resource).to receive(:bucket).with("bulk").and_return(s3_bucket)
+              expect(s3_bucket).to receive(:object).with("directory/second_directory/test.csv").and_return(s3_object)
+              expect(s3_object).to receive(:delete).and_return(result)
+
+              response = described_class.run(bucket, file_name, options)
+              expect(response).to_not be_successful
+            end
           end
         end
       end

--- a/spec/lib/defra_ruby/aws/services/presigned_url_service_spec.rb
+++ b/spec/lib/defra_ruby/aws/services/presigned_url_service_spec.rb
@@ -26,6 +26,19 @@ module DefraRuby
           expect(presigned_url).to include("Amz-Credential")
           expect(presigned_url).to include("Amz-Signature")
         end
+
+        context "when an s3_directory is provided" do
+          let(:presigned_url) { described_class.run(bucket, "testfile.csv", { s3_directory: "directory" }) }
+
+          it "returns a presigned url for a given file in the bucket" do
+            expect(presigned_url).to include("https://test.s3.eu-west-1.amazonaws.com/directory/testfile.csv")
+            expect(presigned_url).to include("response-content-disposition=attachment")
+            expect(presigned_url).to include("response-content-type=text%2Fcsv")
+            expect(presigned_url).to include("Amz-Expires")
+            expect(presigned_url).to include("Amz-Credential")
+            expect(presigned_url).to include("Amz-Signature")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
We need to be able to upload files to S3 in a "subfolder" (or at least with a prefix attached so it looks like this).

This is so we can adapt to the EPR changes and upload files to EPR/export.csv, rather than export.csv.