### PR TITLE
chore/RUBY-4020_aws_deprecation_warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,10 @@ jobs:
 
       - name: Analyze with SonarCloud
         uses: sonarsource/sonarcloud-github-action@v2
-          with:
-            args: >
-              -Dsonar.projectKey=DEFRA_defra-ruby-aws
-              -Dsonar.organization=defra
+        with:
+          args: >
+            -Dsonar.projectKey=DEFRA_defra-ruby-aws
+            -Dsonar.organization=defra
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
 
       - name: Analyze with SonarCloud
         uses: sonarsource/sonarcloud-github-action@v2
+          with:
+            args: >
+              -Dsonar.projectKey=DEFRA_defra-ruby-aws
+              -Dsonar.organization=defra
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,6 @@ jobs:
 
       - name: Analyze with SonarCloud
         uses: sonarsource/sonarcloud-github-action@v2
-        with:
-          args: >
-            -Dsonar.projectKey=DEFRA_defra-ruby-aws
-            -Dsonar.organization=defra
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           sed -i 's/\/home\/runner\/work\/defra-ruby-aws\/defra-ruby-aws\//\/github\/workspace\//g' coverage/.resultset.json
 
       - name: Analyze with SonarCloud
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: sonarsource/sonarqube-scan-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           sed -i 's/\/home\/runner\/work\/defra-ruby-aws\/defra-ruby-aws\//\/github\/workspace\//g' coverage/.resultset.json
 
       - name: Analyze with SonarCloud
-        uses: sonarsource/sonarqube-scan-action@master
+        uses: sonarsource/sonarcloud-github-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,6 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in defra-ruby-aws.gemspec
 gemspec
+
+# version 1.16.2 has a syntax error
+gem "console", "< 1.16.2"

--- a/defra_ruby_aws.gemspec
+++ b/defra_ruby_aws.gemspec
@@ -30,8 +30,10 @@ Gem::Specification.new do |spec|
       "public gem pushes."
   end
 
-  # Use the AWS SDK to interact with S3
-  spec.add_dependency "aws-sdk-s3"
+  # Use the AWS SDK to interact with S3.
+  # Pin the version for now to avoid deprecation warning in some services.
+  # TODO: Refactor to address the deprecation warning and unpin.
+  spec.add_dependency "aws-sdk-s3", "< 1.197"
 
   spec.add_development_dependency "defra_ruby_style"
   # Shim to load environment variables from a .env file into ENV


### PR DESCRIPTION
This change pins the `aws-sdk-s3` gem version to avoid a distracting deprecation warning. There is a separate ticket https://eaflood.atlassian.net/browse/RUBY-4023 to refactor the gem to remove the deprecation warning.
https://eaflood.atlassian.net/browse/RUBY-4020